### PR TITLE
Typo fixes  from Debian

### DIFF
--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -408,7 +408,7 @@ bool Execute()
 	if(!myTree.SetupRoot(vssSeqs, vuSeqLen, vvdRates))
 		return DawgError("Bad root parameters");
 
-	// Read Out.Block.* from file if neccessary
+	// Read Out.Block.* from file if necessary
    	if(!ssOutBlockHead.empty())
 	{
 		ifstream iFile(ssOutBlockHead.c_str());

--- a/src/dawgtxt.h
+++ b/src/dawgtxt.h
@@ -9,7 +9,7 @@
 "  -v: display version information\n" \
 "  -h: display help information\n" \
 "  -?: same as -h\n" \
-"  -o outputfile: override ouput filename in the configuration file\n" \
+"  -o outputfile: override output filename in the configuration file\n" \
 "\n" \
 "  Dawg will read stdin if filename is \"-\".\n" \
 "\n" \

--- a/src/rand.h
+++ b/src/rand.h
@@ -168,7 +168,7 @@ inline uint32_t rand_poisson(double lambda)
 {
 	uint32_t u = 0;
 	double d, e = exp(-lambda);
-	// effecient for lambda < 12
+	// efficient for lambda < 12
 	d = rand_real();
 	while(d > e) {++u; d*=rand_real();}
 	return u;

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -690,7 +690,7 @@ void Tree::Align(Alignment &aln, unsigned int uFlags) const
 	unsigned int uState = 1;
 	unsigned int uColor = 0;
 	unsigned int uColorN = 0;
-	// Go through each column, adding gaps where neccessary
+	// Go through each column, adding gaps where necessary
 	while(uState != 0) {
 		uState = 0; // Set to quit
 		uColor = 0; // Set to lowest color

--- a/src/var.h
+++ b/src/var.h
@@ -108,7 +108,7 @@ public:
 		return ( pVar != NULL && pVar->Get(r) );
 	}
 
-	// Get as array filling in values as neccessary.
+	// Get as array filling in values as necessary.
 	// An array has a set length.
 	template<class T>
 	Vec::size_type GetArray(T ar[], Vec::size_type uSize, bool bExpand=true)
@@ -148,7 +148,7 @@ public:
 		return true;
 	}
 
-	// Get as matrix, filling in rows as neccessary
+	// Get as matrix, filling in rows as necessary
 	// A matrix is an array of vectors.
 	template< class T >
 	Vec::size_type GetMatrix(std::vector<T> ar[], Vec::size_type uSize, bool bExpand=true)
@@ -176,7 +176,7 @@ public:
 				return 0;
 			u = 1;
 		}
-		// fill-in rows as neccessary
+		// fill-in rows as necessary
 		for(; bExpand && u<uSize; u++)
 			ar[u] = ar[0];
 		return u;


### PR DESCRIPTION
Debian's build tools do an automatic spell check on code and binaries. This caught several trivial typos.

Note that this is the only patch from the Debian package that hasn't been resolved already in the github copy of the source.

Cheers,
Kevin
