### PR TITLE
Add "zero" rate to the rate_model class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# intelliJ stuff
+.idea/
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+
+# Compiled Dynamic libraries
+*.so
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+
+# Data files
+*.glf
+*.sam
+*.fa
+*.fai
+
+# misc
+dawg
+*~
+*temp*
+.DS_*
+*.chain
+
+bk
+.gitignore
+.Rhistory
+
+# cmake stuff
+CMakeCache.txt
+CMakeFiles
+Makefile
+cmake_install.cmake
+install_manifest.txt
+src/version.h
+src/config.h
+
+# Ignore the build directory
+build/*
+!build/.gitkeep

--- a/examples/basic-dna-zero-rate.dawg
+++ b/examples/basic-dna-zero-rate.dawg
@@ -3,7 +3,7 @@
 # Simulation results are sent to stdout.
 
 ## Tree Section ################################################################
-# 
+#
 # Use a constant tree.
 
 [Tree]
@@ -16,8 +16,9 @@ Tree = "((Man:0.1,Monkey:0.1):0.2,Dawg:0.25);"
 
 [Subst]
 Model = "HKY"
-Params = 2.0, 1.0 
+Params = 2.0, 1.0
 Freqs = 0.3, 0.2, 0.2, 0.3
+Rate.Model = "ZERO"
 
 ## Root Section ################################################################
 #
@@ -32,4 +33,3 @@ Length = 1000
 
 [Sim]
 Reps = 10
-

--- a/src/include/dawg/rate.h
+++ b/src/include/dawg/rate.h
@@ -24,18 +24,21 @@ public:
 	bool create(const std::string &rname, It first, It last) {
 		static std::string name_keys[] = {
 			std::string("const"),
-			std::string("gamma-invariant")
+			std::string("gamma-invariant"),
+            std::string("zero")
 		};
 		switch(key_switch(rname, name_keys)) {
 			case 0:
 				return create_const(first, last);
 			case 1:
 				return create_gamma(first, last);
+            case 2:
+                return create_zero(first, last);
 		};
 		return DAWG_ERROR("Invalid rate model; no model named '" << rname << "'");		
 		
 	}
-	
+
 	template<typename It>
 	inline bool create_const(It first, It last) {
 		name_ = "const";
@@ -110,7 +113,16 @@ public:
 		name_ = "gamma-invariant";
 		return true;
 	}
-	
+
+    template<typename It>
+    inline bool create_zero(It first, It last) {
+        name_ = "zero";
+        weights_.assign(1, 1.0f);
+        sample_.create(weights_);
+        values_.assign(1, 0.0f);
+        return true;
+    }
+
 	inline const std::string& label() const {
 		return name_;
 	}


### PR DESCRIPTION
This PR address issues #7 and #5 by adding a "zero' rate to the `rate_model` class and also a `.gitignore` file to the project structure. The zero rate can be tested by using the `basic-dna-zero-rate.dawg` file in the examples. The expected output should be similar to the `basic-dng.dawg` example (?).
