### PR TITLE
Fix two example dawg tricks from blowing up

### DIFF
--- a/examples/basic-dna-2.dawg
+++ b/examples/basic-dna-2.dawg
@@ -4,7 +4,7 @@
 Tree.Tree = "((Man:0.1,Monkey:0.1):0.2,Dawg:0.25);"
 Subst.Model = "HKY"
 Subst.Params = 2.0, 1.0 
-Freqs = 0.3, 0.2, 0.2, 0.3
+Subst.Freqs = 0.3, 0.2, 0.2, 0.3
 Root.Length = 1000
 Sim.Reps = 10
 

--- a/examples/segments.dawg
+++ b/examples/segments.dawg
@@ -20,7 +20,7 @@ Root.Length = 10
 Subst.Model = codmg
 Subst.Params = 0.1, 1, 1, 1, 1, 1, 1
 Subst.Freqs  = 0.2, 0.3, 0.3, 0.2
-Root.Code = 100
+# Root.Code = 100
 
 # Another section to control segment 3.  Clone parameters from "Noncoding"
 # section.


### PR DESCRIPTION
This pull request addresses issue #6 . To verify run the two examples noted below and verify the output.
- Add Subst.Freqs in basic-dna-2.dawg example
- Modify segments.dawg example to not use invalid Root.Code

The `pseudogene.dawg` example appears incomplete.
