### PR TITLE
Use boost::optional instead of boost::tribool

### DIFF
--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -137,9 +137,9 @@ int dawg_app::run() {
 	//bool split  = (!vm["split"].defaulted()) ? arg.split : glopts.output_split;
 	//bool append = (!vm["append"].defaulted()) ? arg.append : glopts.output_append;
 
-	bool split  = arg.split || (indeterminate(arg.split) && glopts.output_split);
-	bool append = arg.append || (indeterminate(arg.append) && glopts.output_append);
-	bool label  = arg.label || (indeterminate(arg.label) && glopts.output_label);
+	bool split  = (bool) arg.split || (indeterminate(arg.split) && glopts.output_split);
+	bool append = (bool) arg.append || (indeterminate(arg.append) && glopts.output_append);
+	bool label  = (bool) arg.label || (indeterminate(arg.label) && glopts.output_label);
 
 	if(!write_aln.open(file_name, num_reps-1, split, append, label)) {
 		DAWG_ERROR("bad configuration");

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -137,9 +137,9 @@ int dawg_app::run() {
 	//bool split  = (!vm["split"].defaulted()) ? arg.split : glopts.output_split;
 	//bool append = (!vm["append"].defaulted()) ? arg.append : glopts.output_append;
 
-	bool split  = arg.split || (arg.split == boost::none && glopts.output_split);
-	bool append = arg.append || (arg.append == boost::none && glopts.output_append);
-	bool label  = arg.label || (arg.label == boost::none && glopts.output_label);
+	bool split  = (arg.split != boost::none) ? arg.split.value() : glopts.output_split;
+	bool append = (arg.append != boost::none) ? arg.append.value() : glopts.output_append;
+	bool label  = (arg.label != boost::none) ? arg.label.value() : glopts.output_label;
 
 	if(!write_aln.open(file_name, num_reps-1, split, append, label)) {
 		DAWG_ERROR("bad configuration");

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -137,9 +137,9 @@ int dawg_app::run() {
 	//bool split  = (!vm["split"].defaulted()) ? arg.split : glopts.output_split;
 	//bool append = (!vm["append"].defaulted()) ? arg.append : glopts.output_append;
 
-	bool split  = (bool) arg.split || (indeterminate(arg.split) && glopts.output_split);
-	bool append = (bool) arg.append || (indeterminate(arg.append) && glopts.output_append);
-	bool label  = (bool) arg.label || (indeterminate(arg.label) && glopts.output_label);
+	bool split  = arg.split || (arg.split == boost::none && glopts.output_split);
+	bool append = arg.append || (arg.append == boost::none && glopts.output_append);
+	bool label  = arg.label || (arg.label == boost::none && glopts.output_label);
 
 	if(!write_aln.open(file_name, num_reps-1, split, append, label)) {
 		DAWG_ERROR("bad configuration");

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -137,9 +137,9 @@ int dawg_app::run() {
 	//bool split  = (!vm["split"].defaulted()) ? arg.split : glopts.output_split;
 	//bool append = (!vm["append"].defaulted()) ? arg.append : glopts.output_append;
 
-	bool split  = (arg.split != boost::none) ? arg.split.value() : glopts.output_split;
-	bool append = (arg.append != boost::none) ? arg.append.value() : glopts.output_append;
-	bool label  = (arg.label != boost::none) ? arg.label.value() : glopts.output_label;
+	bool split  = arg.split.value_or(glopts.output_split);
+	bool append = arg.append.value_or(glopts.output_append);
+	bool label  = arg.label.value_or(glopts.output_label);
 
 	if(!write_aln.open(file_name, num_reps-1, split, append, label)) {
 		DAWG_ERROR("bad configuration");

--- a/src/dawgarg.xmh
+++ b/src/dawgarg.xmh
@@ -30,9 +30,9 @@ XM((help),           , "display help message", bool, DL(false, "off"))
 XM((output),    (o),  "output to this file", std::string, std::string())
 XM((seed),         ,  "PRNG seed", unsigned int, 0)
 XM((reps),         ,  "the number of alignments to generate", unsigned int, 0)
-XM((split),        ,  "split output into separate files", boost::tribool, DL(boost::indeterminate, "null"))
-XM((append),       ,  "append output to file", boost::tribool, DL(boost::indeterminate, "null"))
-XM((label),        ,  "label each simulation with a unique id", boost::tribool, DL(boost::indeterminate, "null"))
+XM((split),        ,  "split output into separate files", boost::optional<bool>, DL(boost::none, "not defined"))
+XM((append),       ,  "append output to file", boost::optional<bool>, DL(boost::none, "not defined"))
+XM((label),        ,  "label each simulation with a unique id", boost::optional<bool>, DL(boost::none, "not defined"))
 
 XM((arg)(file),    ,   "read arguments from file", std::string, std::string(""))
 


### PR DESCRIPTION
Since boost 1.69 updated Logic library: "Breaking change: Use explicit operator bool when available ([PR#5](https://github.com/boostorg/logic/pull/5)) conversion from `boost::logic::tribool` to `bool` needs an explicit conversion to prevent compiling errors.
