### PR TITLE
Increment maximum number of node IDs

### DIFF
--- a/src/include/dawg/wood.h
+++ b/src/include/dawg/wood.h
@@ -17,7 +17,7 @@
 namespace dawg {
 
 struct wood_node {
-	typedef unsigned short id_t;
+	typedef uint32_t id_t;
 	std::string label;
 	float length;
 	id_t anc;


### PR DESCRIPTION
Increment number of node IDs that dawg can store by upsizing from 16 to 32 unsigned bits.
This will allow dawg to properly handle larger input trees.