### PR TITLE
Migrate from boost program options to CLI11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,7 @@ src/config.h
 
 # Ignore the build directory
 build/*
-!build/.gitkeep
+builddir/*
+
+# Ignore workspace
+*.sublime-workspace

--- a/contrib/CLI/CLI11.hpp
+++ b/contrib/CLI/CLI11.hpp
@@ -4843,8 +4843,8 @@ class App {
         set_help_flag("-h,--help", "Print this help message and exit");
     }
 
-    App(const App &) = delete;
-    App &operator=(const App &) = delete;
+    App(const App &) = default;
+    App &operator=(const App &) = default;
 
     /// virtual destructor
     virtual ~App() = default;

--- a/contrib/CLI/CLI11.hpp
+++ b/contrib/CLI/CLI11.hpp
@@ -4843,8 +4843,8 @@ class App {
         set_help_flag("-h,--help", "Print this help message and exit");
     }
 
-    App(const App &) = default;
-    App &operator=(const App &) = default;
+    App(const App &) = delete;
+    App &operator=(const App &) = delete;
 
     /// virtual destructor
     virtual ~App() = default;

--- a/dawg.sublime-project.in
+++ b/dawg.sublime-project.in
@@ -1,0 +1,31 @@
+{
+	"folders":
+	[
+		{
+			"path": "@source_dir@",
+			"folder_exclude_patterns":["builddir"]
+		}
+	],
+	"settings": {
+		"tab_size": 4,
+		"translate_tabs_to_spaces": true
+		// "ClangFormat": {
+		// 	"format_on_save": true
+		// }
+	},
+	"build_systems":
+	[
+		{
+			"name": "@project_name@ - default",
+			"cmd": ["meson", "compile", "-C", "@build_dir@"],
+			"working_dir": "${project_path}",
+			"file_regex": "^(..[^:]*):([0-9]+):?([0-9]+)?:? (.*)$"
+		},
+		{
+			"name": "@project_name@ - test",
+			"cmd": ["meson", "test", "-C", "@build_dir@"],
+			"working_dir": "${project_path}",
+			"file_regex": "^(..[^:]*):([0-9]+):?([0-9]+)?:? (.*)$"
+		}
+    ]
+}

--- a/meson.build
+++ b/meson.build
@@ -13,3 +13,12 @@ subdir('contrib')
 subdir('src')
 subdir('doc')
 # subdir('tests')
+
+configure_file(input : 'dawg.sublime-project.in',
+  output : 'dawg.sublime-project',
+  configuration : {
+    'source_dir' : meson.project_source_root(),
+    'project_name' : meson.project_name(),
+    'build_dir' : meson.project_build_root()
+  }
+)

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -17,7 +17,6 @@
 */
 #include "dawg.h"
 
-// #include <boost/config.hpp>
 #include <CLI11.hpp>
 #include <boost/preprocessor.hpp>
 #include <exception>
@@ -29,10 +28,6 @@
 #include "dawg/output.h"
 #include "dawg/trick.h"
 #include "dawg_app.h"
-
-// using namespace std;
-// using namespace boost;
-// using namespace dawg;
 
 #define VERSION_MSG                                         \
     DAWG_PACKAGE_STRING                                     \
@@ -52,17 +47,16 @@ int main(int argc, char *argv[]) {
 }
 
 dawg_app::dawg_app(int argc, char *argv[]) : runname(argv[0]) {
-    // runname = argv[0];
-
     // set_cli_options
     this->cli_app.add_option("input", arg.input, "input files");
 #define XM(lname, sname, desc, type, def)                            \
-    this->cli_app.add_option(                                                  \
+    this->cli_app.add_option(                                        \
         IFD(sname, "-" BOOST_PP_STRINGIZE sname ",") "--" XS(lname), \
         arg.XV(lname), desc, def);
-#define XF(lname, sname, desc, type, def)                                     \
-    this->cli_app.add_flag(IFD(sname, "-" BOOST_PP_STRINGIZE sname ",") "--" XS(lname), \
-                 arg.XV(lname), desc);
+#define XF(lname, sname, desc, type, def)                            \
+    this->cli_app.add_flag(                                          \
+        IFD(sname, "-" BOOST_PP_STRINGIZE sname ",") "--" XS(lname), \
+        arg.XV(lname), desc);
 #include "dawgarg.xmh"
 #undef XM
 #undef XF

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -17,7 +17,8 @@
 */
 #include "dawg.h"
 
-#include <boost/config.hpp>
+// #include <boost/config.hpp>
+#include <CLI11.hpp>
 #include <boost/preprocessor.hpp>
 #include <exception>
 
@@ -29,9 +30,9 @@
 #include "dawg/trick.h"
 #include "dawg_app.h"
 
-using namespace std;
-using namespace boost;
-using namespace dawg;
+// using namespace std;
+// using namespace boost;
+// using namespace dawg;
 
 #define VERSION_MSG                                         \
     DAWG_PACKAGE_STRING                                     \
@@ -50,43 +51,26 @@ int main(int argc, char *argv[]) {
     return ret;
 }
 
-dawg_app::dawg_app(int argc, char *argv[]) : desc("Allowed Options") {
-    runname = argv[0];
-    try {
-        desc.add_options()
-#define XM(lname, sname, desc, type, def)                \
-    (XS(lname) IFD(sname, "," BOOST_PP_STRINGIZE sname), \
-     po::value<type>(&arg.XV(lname))->default_value(def), desc)
+dawg_app::dawg_app(int argc, char *argv[]) : runname(argv[0]) {
+    // runname = argv[0];
+
+    // set_cli_options
+    this->cli_app.add_option("input", arg.input, "input files");
+#define XM(lname, sname, desc, type, def)                            \
+    this->cli_app.add_option(                                                  \
+        IFD(sname, "-" BOOST_PP_STRINGIZE sname ",") "--" XS(lname), \
+        arg.XV(lname), desc, def);
+#define XF(lname, sname, desc, type, def)                                     \
+    this->cli_app.add_flag(IFD(sname, "-" BOOST_PP_STRINGIZE sname ",") "--" XS(lname), \
+                 arg.XV(lname), desc);
 #include "dawgarg.xmh"
 #undef XM
-            ;
-        indesc.add_options()("input", po::value<vector<string> >(&arg.input),
-                             "input files");
-        indesc.add(desc);
-        pdesc.add("input", -1);
-        po::store(po::command_line_parser(argc, argv)
-                      .options(indesc)
-                      .positional(pdesc)
-                      .run(),
-                  vm);
-        po::notify(vm);
-        if(!arg.arg_file.empty()) {
-            if(arg.arg_file == "-") {
-                po::store(po::parse_config_file(cin, desc), vm);
-            } else {
-                std::ifstream ifs(arg.arg_file.c_str());
-                if(!ifs.is_open()) {
-                    string sse = "unable to open argument file ";
-                    sse += arg.arg_file;
-                    throw std::runtime_error(sse);
-                }
-                po::store(po::parse_config_file(ifs, desc), vm);
-            }
-            po::notify(vm);
-        }
-    } catch(std::exception &e) {
-        CERROR(e.what());
-        throw std::runtime_error("unable to process command line");
+#undef XF
+
+    try {
+        this->cli_app.parse(argc, argv);
+    } catch(const CLI::CallForHelp &e) {
+        exit(this->cli_app.exit(e));
     }
 }
 
@@ -97,37 +81,34 @@ int dawg_app::run() {
     // | format_all); cout << _out << endl << endl;
 
     if(arg.version) {
-        cerr << endl << VERSION_MSG << endl << endl;
+        std::cerr << std::endl << VERSION_MSG << std::endl << std::endl;
         return EXIT_SUCCESS;
     }
     if(arg.help_trick) {
-        cerr << endl << VERSION_MSG << endl << endl;
-        ma::help(cerr);
+        std::cerr << std::endl << VERSION_MSG << std::endl << std::endl;
+        dawg::ma::help(std::cerr);
         return EXIT_SUCCESS;
     }
-    if(arg.help || arg.input.empty()) {
-        cerr << endl << VERSION_MSG << endl << endl;
-        cerr << "Usage:\n  " << runname
-             << " [options] trick-1.dawg trick-2.dawg ..." << endl
-             << endl;
-        cerr << desc << endl;
+    if(arg.input.empty()) {
+        std::cerr << std::endl << VERSION_MSG << std::endl << std::endl;
+        std::cerr << std::endl << this->cli_app.help() << std::endl;
         return EXIT_SUCCESS;
     }
 
     // if(arg.quiet)
     //	cerr.clear(ios::failbit);
-    trick input;
+    dawg::trick input;
 
     bool ret = true;
-    for(string &ss : arg.input) {
-        ret &= trick::parse_file(input, ss.c_str());
+    for(std::string &ss : arg.input) {
+        ret &= dawg::trick::parse_file(input, ss.c_str());
     }
 
     if(!ret) return EXIT_FAILURE;
     // process aliases
     input.read_aliases();
 
-    global_options glopts;
+    dawg::global_options glopts;
     glopts.read_section(input.data.front());
 
     unsigned int num_reps = (arg.reps > 0) ? arg.reps : glopts.sim_reps;
@@ -135,15 +116,9 @@ int dawg_app::run() {
     dawg::output write_aln;
     const char *file_name =
         arg.output.empty() ? glopts.output_file.c_str() : arg.output.c_str();
-    // bool split  = (!vm["split"].defaulted()) ? arg.split :
-    // glopts.output_split; bool append = (!vm["append"].defaulted()) ?
-    // arg.append : glopts.output_append;
 
-    bool split = arg.split.get_value_or(glopts.output_split);
-    bool append = arg.append.get_value_or(glopts.output_append);
-    bool label = arg.label.get_value_or(glopts.output_label);
-
-    if(!write_aln.open(file_name, num_reps - 1, split, append, label)) {
+    if(!write_aln.open(file_name, num_reps - 1, arg.split, arg.append,
+                       arg.label)) {
         DAWG_ERROR("bad configuration");
         return EXIT_FAILURE;
     }
@@ -152,7 +127,7 @@ int dawg_app::run() {
         glopts.output_block_tail.c_str(), glopts.output_block_before.c_str(),
         glopts.output_block_after.c_str());
 
-    vector<dawg::ma> configs;
+    std::vector<dawg::ma> configs;
     if(!dawg::ma::from_trick(input, configs)) {
         DAWG_ERROR("bad configuration");
         return EXIT_FAILURE;

--- a/src/dawg_app.h
+++ b/src/dawg_app.h
@@ -28,12 +28,12 @@
 
 class dawg_app {
    public:
-    dawg_app(int argc, char *argv[]);
-    dawg_app(const dawg_app&) = default;        // copy constructor
-    dawg_app& operator=(const dawg_app&);       // copy assignment operator
-    dawg_app(dawg_app&&) = default;             // move constructor
-    dawg_app& operator=(dawg_app&&) = default;  // move assignment operator
-    virtual ~dawg_app() = default;              // destructor
+    dawg_app(int argc, char* argv[]);
+    dawg_app(const dawg_app&) = delete;             // copy constructor
+    dawg_app& operator=(const dawg_app&) = delete;  // copy assignment operator
+    dawg_app(dawg_app&&) = delete;                  // move constructor
+    dawg_app& operator=(dawg_app&&) = delete;       // move assignment operator
+    virtual ~dawg_app() = default;                  // destructor
 
     virtual int run();
 

--- a/src/dawg_app.h
+++ b/src/dawg_app.h
@@ -18,98 +18,39 @@
 #ifndef DAWG_APP_H
 #define DAWG_APP_H
 
-#include <vector>
+#include <CLI11.hpp>
 #include <utility>
-
-#include <boost/logic/tribool.hpp>
-#include <boost/logic/tribool_io.hpp>
-#include <boost/program_options.hpp>
-namespace po = boost::program_options;
-
-namespace boost {
-void validate(boost::any& v, const std::vector<std::string>& xs, boost::tribool*, int) {
-    using namespace boost::program_options;
-    validators::check_first_occurrence(v);
-	std::string s(validators::get_single_string(xs, true));
-
-    for (size_t i = 0; i < s.size(); ++i)
-        s[i] = char(tolower(s[i]));
-
-    if (s.empty() || s == "on" || s == "yes" || s == "1" || s == "true")
-		v = boost::any(boost::tribool(true));
-    else if (s == "off" || s == "no" || s == "0" || s == "false")
-		v = boost::any(boost::tribool(false));
-    else if (s == "null" || s == "maybe" || s == "2" || s == "indeterminate")
-		v = boost::any(boost::tribool(boost::indeterminate));
-    else
-        boost::throw_exception(validation_error(validation_error::invalid_option_value, s));
-}
-#if !defined(BOOST_NO_STD_WSTRING)
-void validate(boost::any& v, const std::vector<std::wstring>& xs, boost::tribool*, int) {
-    using namespace boost::program_options;
-    validators::check_first_occurrence(v);
-	std::wstring s(validators::get_single_string(xs, true));
-
-    for (size_t i = 0; i < s.size(); ++i)
-        s[i] = char(tolower(s[i]));
-
-    if (s.empty() || s == L"on" || s == L"yes" || s == L"1" || s == L"true")
-		v = boost::any(boost::tribool(true));
-    else if (s == L"off" || s == L"no" || s == L"0" || s == L"false")
-		v = boost::any(boost::tribool(false));
-    else if (s == L"null" || s == L"maybe" || s == L"2" || s == L"indeterminate")
-		v = boost::any(boost::tribool(boost::indeterminate));
-    else
-        boost::throw_exception(validation_error(validation_error::invalid_option_value));
-}
-#endif
-}
-
-namespace boost { namespace program_options {
-template<>
-typed_value<bool>* value(bool* v) {
-	return bool_switch(v);
-	//typed_value<bool>* r = new typed_value<bool>(v);
-    //r->default_value(0, "off");
-    //r->implicit_value(1, "on");
-	//return r;
-}
-template<>
-typed_value<boost::tribool>* value(boost::tribool* v) {
-	//return bool_switch(v);
-	typed_value<boost::tribool>* r = new typed_value<boost::tribool>(v);
-    r->implicit_value(true, "on");
-	return r;
-}
-}}
+#include <vector>
 
 /****************************************************************************
  *    class dawg_app                                                        *
  ****************************************************************************/
 
-class dawg_app  {
-public:
-	dawg_app(int argc, char *argv[]);
-	virtual ~dawg_app() { }
-	
-	virtual int run();
+class dawg_app {
+   public:
+    dawg_app(int argc, char *argv[]);
+    dawg_app(const dawg_app&) = default;        // copy constructor
+    dawg_app& operator=(const dawg_app&);       // copy assignment operator
+    dawg_app(dawg_app&&) = default;             // move constructor
+    dawg_app& operator=(dawg_app&&) = default;  // move assignment operator
+    virtual ~dawg_app() = default;              // destructor
 
-	std::string runname;
-	po::options_description desc, indesc;
-	po::positional_options_description pdesc;
-	po::variables_map vm;
+    virtual int run();
 
-	struct args
-	{			
-	// use X-Macros to specify argument variables
-#	define XM(lname, sname, desc, type, def) type XV(lname) ;
-#	include "dawgarg.xmh"
-#	undef XM
-		std::vector< std::string > input;
-	};
-	
-protected:
-	args arg;
+    struct args {
+        // use X-Macros to specify argument variables
+#define XM(lname, sname, desc, type, def) type XV(lname);
+#define XF(lname, sname, desc, type, def) type XV(lname);
+#include "dawgarg.xmh"
+#undef XM
+#undef XF
+        std::vector<std::string> input;
+    };
+
+   private:
+    args arg;
+    CLI::App cli_app;
+    std::string runname{""};
 };
 
 #endif

--- a/src/dawgarg.xmh
+++ b/src/dawgarg.xmh
@@ -20,38 +20,37 @@
 /***************************************************************************
  *    X-Macro List                                                         *
  *                                                                         *
- *    XCMD(lname, sname, desc, type, def)                                  *
+ *    XM(lname, sname, desc, type, def) (option)                           *
+ *    XF(lname, sname, desc, type, def) (flag)                             *
  ***************************************************************************/
 
-XM((version),        , "display version information", bool, DL(false, "off"))
-XM((help)(trick),    , "display description of common control variables", bool, DL(false, "off"))
-XM((help),           , "display help message", bool, DL(false, "off"))
+XF((version), , "display version information", bool, false)
+XF((help)(trick), , "display description of common control variables", bool,
+   false)
 
-XM((output),    (o),  "output to this file", std::string, std::string())
-XM((seed),         ,  "PRNG seed", unsigned int, 0)
-XM((reps),         ,  "the number of alignments to generate", unsigned int, 0)
-XM((split),        ,  "split output into separate files", boost::optional<bool>, DL(boost::none, "not defined"))
-XM((append),       ,  "append output to file", boost::optional<bool>, DL(boost::none, "not defined"))
-XM((label),        ,  "label each simulation with a unique id", boost::optional<bool>, DL(boost::none, "not defined"))
+XM((output), (o), "output to this file", std::string, "")
+XM((seed), , "PRNG seed", unsigned int, 0)
+XM((reps), , "the number of alignments to generate", unsigned int, 0)
+XF((split), , "split output into separate files", bool, false)
+XF((append), , "append output to file", bool, false)
+XF((label), , "label each simulation with a unique id", bool, false)
 
-XM((arg)(file),    ,   "read arguments from file", std::string, std::string(""))
+XM((arg)(file), , "read arguments from file", std::string, "")
 
-//XCMD((serial),  (s), "Process input files serially", bool, true)
-//XCMD((combined),(c), "process input files together", bool, false)
-//XCMD((buffer),  (b), "buffer output", bool, true)
-//XCMD((unbuffer),  (u), "unbuffered output", bool, false)
+// XCMD((serial),  (s), "Process input files serially", bool, true)
+// XCMD((combined),(c), "process input files together", bool, false)
+// XCMD((buffer),  (b), "buffer output", bool, true)
+// XCMD((unbuffer),  (u), "unbuffered output", bool, false)
 
 // Standard options
-//XM((quiet),       (q), "disable all warnings and error messages", bool, DL(false, "off"))
-//XM((warn),        (w), "dsable warnings", bool, DL(false, "off"))
-//XM((error),       (e), "disable error messages", bool, DL(false, "off"))
-//XM((input),          , "input files", std::vector< std::string >, DL(std::vector< std::string >(1, std::string("-")), "-") )
-//XM((input),          , "input files", std::vector< std::string >, DL(std::vector< std::string >(), "") )
-
+// XM((quiet),       (q), "disable all warnings and error messages", bool,
+// false) XM((warn),        (w), "dsable warnings", bool, false) XM((error),
+// (e), "disable error messages", bool, false) XM((input),          , "input
+// files", std::vector< std::string >, DL(std::vector< std::string >(1,
+// std::string("-")), "-") ) XM((input),          , "input files", std::vector<
+// std::string >, DL(std::vector< std::string >(), "") )
 
 /***************************************************************************
  *    cleanup                                                              *
  ***************************************************************************/
 #include "dawg/details/xm.h"
-
-

--- a/src/include/dawg/details/xm.h
+++ b/src/include/dawg/details/xm.h
@@ -33,30 +33,32 @@
 
 #define JS_OP(s, data, elem) BOOST_PP_CAT(data, elem)
 
-#define JS(sep, seq) BOOST_PP_IF( BOOST_PP_EQUAL(BOOST_PP_SEQ_SIZE(seq),1), \
-	JS_1, JS_2)(sep,seq)
+#define JS(sep, seq) \
+    BOOST_PP_IF(BOOST_PP_EQUAL(BOOST_PP_SEQ_SIZE(seq), 1), JS_1, JS_2)(sep, seq)
 
 #define JS_1(sep, seq) BOOST_PP_SEQ_HEAD(seq)
 
-#define JS_2(sep, seq) BOOST_PP_SEQ_CAT(( BOOST_PP_SEQ_HEAD(seq) ) \
-	BOOST_PP_SEQ_TRANSFORM(JS_OP, sep, BOOST_PP_SEQ_TAIL(seq)) \
-)
+#define JS_2(sep, seq)                                               \
+    BOOST_PP_SEQ_CAT((BOOST_PP_SEQ_HEAD(seq))BOOST_PP_SEQ_TRANSFORM( \
+        JS_OP, sep, BOOST_PP_SEQ_TAIL(seq)))
 
 // The SS macro is similiar to _JS except that it stringizes everything
 
 #define SS_OP(r, data, elem) data BOOST_PP_STRINGIZE(elem)
 
-#define SS(sep, seq) BOOST_PP_STRINGIZE(BOOST_PP_SEQ_HEAD(seq)) \
-	BOOST_PP_SEQ_FOR_EACH(SS_OP, sep, BOOST_PP_SEQ_TAIL(seq))
+#define SS(sep, seq)                           \
+    BOOST_PP_STRINGIZE(BOOST_PP_SEQ_HEAD(seq)) \
+    BOOST_PP_SEQ_FOR_EACH(SS_OP, sep, BOOST_PP_SEQ_TAIL(seq))
 
 // Output result if seq is defined
 
-#define IFD(seq,res) BOOST_PP_EXPR_IF(BOOST_PP_GREATER(BOOST_PP_SEQ_SIZE((_)seq),1), res)
+#define IFD(seq, res) \
+    BOOST_PP_EXPR_IF(BOOST_PP_GREATER(BOOST_PP_SEQ_SIZE((_)seq), 1), res)
 
 #define XV(lname) JS(_, lname)
 #define XS(lname) SS("-", lname)
 #define XP(lname) SS(".", lname)
-#define DL(a,b) a,b
+#define DL(a, b) a, b
 
 #else
 
@@ -72,7 +74,6 @@
 #undef XV
 #undef XS
 #undef XP
-#undef XL
+#undef DL
 
 #endif
-

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,7 +19,6 @@ inc = include_directories(['.', 'include'])
 
 boost_dep = dependency('boost',
   version : '>=1.47.0',
-  modules : ['program_options'],
   required : true
 )
 


### PR DESCRIPTION
- Remove `boost::program_options` dependency.
- Split arguments into options and flags, according to CLI11 syntax.
- Fix `clang-tidy` errors and warnings and format according to `clang-format` syntax.
- Add sublime text configuration file.